### PR TITLE
Update FluxBuilder.java

### DIFF
--- a/flux-core/src/main/java/org/apache/storm/flux/FluxBuilder.java
+++ b/flux-core/src/main/java/org/apache/storm/flux/FluxBuilder.java
@@ -61,7 +61,7 @@ public class FluxBuilder {
      * @throws NoSuchMethodException
      * @throws InvocationTargetException
      */
-    static StormTopology buildTopology(ExecutionContext context) throws IllegalAccessException,
+    public static StormTopology buildTopology(ExecutionContext context) throws IllegalAccessException,
             InstantiationException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException {
 
         StormTopology topology = null;


### PR DESCRIPTION
The method "buildTopology" previously had a public access modifier, latest snapshot did not and rendered it inaccessible from object call. Re-applying public access modifier.
